### PR TITLE
fix: prepublish was removed since it is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "resources/",
     "nail/plantumlnail.jar",
     "scripts/download.js",
-    "scripts/get-vizjs.js"
+    "scripts/get-vizjs.js",
+    "scripts/get-plantuml-jar.js"
   ],
   "scripts": {
     "prepublish": "node scripts/get-plantuml-jar.js",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "scripts/get-plantuml-jar.js"
   ],
   "scripts": {
-    "prepublish": "node scripts/get-plantuml-jar.js",
     "postinstall": "node scripts/get-vizjs.js && node scripts/get-plantuml-jar.js",
     "test": "standard && node test/fixtures/prepare.js && mocha",
     "build": "node nail/build.js"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "prepublish": "node scripts/get-plantuml-jar.js",
-    "postinstall": "node scripts/get-vizjs.js",
+    "postinstall": "node scripts/get-vizjs.js && node scripts/get-plantuml-jar.js",
     "test": "standard && node test/fixtures/prepare.js && mocha",
     "build": "node nail/build.js"
   },


### PR DESCRIPTION
`prepublish `does not seem to work properly when using yarn install.

Therefore the `get-plantuml `script is now executed in `postInstall `stage.

